### PR TITLE
Set `Server.offline_since` correctly

### DIFF
--- a/nogamespy/models.py
+++ b/nogamespy/models.py
@@ -152,7 +152,7 @@ def remove_offline_entities():
 
     servers_went_offline = Server.query.filter(
         Server.online == False,
-        Server.offline_since is None,
+        Server.offline_since.is_(None),
     ).update({
         'offline_since': datetime.now(),
     }, synchronize_session='fetch')
@@ -171,4 +171,4 @@ def remove_offline_entities():
         logger.debug(f'{servers_went_offline} servers went offline.')
 
     if servers_deleted:
-        logger.debug(f'{servers_deleted} offline servers deleted.')
+        logger.info(f'{servers_deleted} offline servers deleted.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ raven
 requests
 sqlalchemy
 statsd
+redis==2.10.6  # temporary fix, whole line can be deleted when dependencies are fixed

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,3 +97,14 @@ def test_remove_offline_entities():
     assert inspect(server1).was_deleted
     assert not inspect(server3).was_deleted
     assert not inspect(player3).was_deleted
+
+
+def test_set_server_offline_since():
+    server = factories.Server(online=False)
+
+    db_session.add(server)
+    db_session.commit()
+
+    models.remove_offline_entities()
+
+    assert datetime.now() - server.offline_since < timedelta(seconds=10)  # "now", but test can run slowly


### PR DESCRIPTION
I can see there's more than 500 servers stored in the production DB. Old ones are not getting removed and are contacted again and again during periodic tasks. That's probably the reason why Datadog metrics regarding DB refreshement are at so low levels (even 0) and the whole system gets overworked.