### PR TITLE
Don't fail when pulling a server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   celery_worker:
     image: garncarz/nogamespy-vietcong
     build: .
-    command: celery worker -A nogamespy -l info
+    command: celery --app nogamespy worker -l info
     volumes:
       - ./volume:/app/volume
     links:
@@ -39,7 +39,7 @@ services:
   celery_beat:
     image: garncarz/nogamespy-vietcong
     build: .
-    command: celery beat -A nogamespy -l info
+    command: celery --app nogamespy beat -l info
     volumes:
       - ./volume:/app/volume
     links:

--- a/nogamespy/tasks.py
+++ b/nogamespy/tasks.py
@@ -144,6 +144,11 @@ def pull_server_info(server):
         logger.exception(f'{server}: GeoIP error')
         statsd.incr('game_server.geoip_error')
         return False
+    
+    except Exception:
+        logger.exception(f'{server}: other error')
+        statsd.incr('game_server.pull_error')
+        return False
 
 
 @task


### PR DESCRIPTION
So Celery chord gets finished.

It errs on this today:
```
celery_worker_1  | [2020-11-11 02:12:09,111][ERROR] celery.backends.redis redis.py:on_chord_part_return:457 | Chord callback for '3
e90fb79-948b-44a3-921a-6edc755dac05' raised: ChordError('Dependency fad8ca58-115c-451f-bb7c-f1b3ae5a6a64 raised Exception(\'<class
\\\'UnicodeDecodeError\\\'>([\\\'ascii\\\', "b\\\'\\\\\\\\xbe\\\\\\\\\\\\\\\\gamever\\\\\\\\\\\\\\\\198\\\\\\\\\\\\\\\\uver\\\\\\\\
\\\\\\\\160\\\\\\\\\\\\\\\\hostport\\\\\\\\\\\\\\\\5425\\\\\\\\\\\\\\\\hostname\\\\\\\\\\\\\\\\Versailles Palace VC Server\\\\\\\\\
\\\\\\\mapname\\\\\\\\\\\\\\\\JungleRuins_VCC_b1\\\\\\\\\\\\\\\\gametype\\\\\\\\\\\\\\\\Coop\\\\\\\\\\\\\\\\gamemode\\\\\\\\\\\\\\\
\openplaying\\\\\\\\\\\\\\\\maxplayers\\\\\\\\\\\\\\\\6\\\\\\\\\\\\\\\\numplayers\\\\\\\\\\\\\\\\0\\\\\\\\\\\\\\\\gamever\\\\\\\\\\
\\\\\\198\\\\\\\\\\\\\\\\voice\\\\\\\\\\\\\\\\2\\\\\\\\\\\\\\\\dedic\\\\\\\\\\\\\\\\1\\\\\\\\\\\\\\\\vietnam\\\\\\\\\\\\\\\\1\\\\\\
\\\\\\\\\\hideip\\\\\\\\\\\\\\\\1\\\\\\\\\\\\\\\\validate\\\\\\\\\\\\\\\\pQAA\\\\\\\\\\\\\\\\weight\\\\\\\\\\\\\\\\10\\\\\\\\\\\\\\
\\final\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\queryid\\\\\\\\\\\\\\\\11529.1\\\'", 0, 1, \\\'ordinal not in range(128)\\\'])\')')
```